### PR TITLE
fix: [AXIMST-719] fixed SCORM xblock rendering

### DIFF
--- a/src/course-unit/course-xblock/xblock-content/iframe-wrapper/iframe-wrapper.js
+++ b/src/course-unit/course-xblock/xblock-content/iframe-wrapper/iframe-wrapper.js
@@ -246,10 +246,15 @@ export default function wrapBlockHtmlForIFrame(html, sourceResources, studioBase
   modifiedHtml = modifyVoidHrefToPreventDefault(html);
   // Due to the use of edx-platform scripts in MFE, it is necessary to ensure that the paths for static files
   // and important data-attributes are correct.
-  modifiedHtml = modifiedHtml.replace('url(&#39;/assets', `url('${studioBaseUrl}/assets`);
-  modifiedHtml = modifiedHtml.replace('src="/assets', `src="${studioBaseUrl}/assets`);
-  modifiedHtml = modifiedHtml.replace('src=&#34;/static/studio', `src=&#34;${studioBaseUrl}/static/studio`);
-  modifiedHtml = modifiedHtml.replace('data-target="/preview/xblock', `data-target="${studioBaseUrl}/preview/xblock`);
+  modifiedHtml = modifiedHtml.replace(/url\(&#39;\/assets/g, `url('${studioBaseUrl}/assets`);
+  modifiedHtml = modifiedHtml.replace(/src="\/asset/g, `src="${studioBaseUrl}/asset`);
+  modifiedHtml = modifiedHtml.replace(/src=&#34;\/asset/g, `src=&#34;${studioBaseUrl}/asset`);
+  modifiedHtml = modifiedHtml.replace(/href="\/asset/g, `href="${studioBaseUrl}/asset`);
+  modifiedHtml = modifiedHtml.replace(/src=&#34;\/static\/studio/g, `src=&#34;${studioBaseUrl}/static/studio`);
+  modifiedHtml = modifiedHtml.replace(/src="\/static/g, `src="${studioBaseUrl}/static`);
+  modifiedHtml = modifiedHtml.replace(/data-target="\/preview\/xblock/g, `data-target="${studioBaseUrl}/preview/xblock`);
+  modifiedHtml = modifiedHtml.replace(/data-url="\/preview/g, `data-url="${studioBaseUrl}/preview`);
+  modifiedHtml = modifiedHtml.replace(/src="\/media/g, `src="${studioBaseUrl}/media`);
 
   if (
     type === COMPONENT_TYPES.discussion


### PR DESCRIPTION
[YouTrack](https://youtrack.raccoongang.com/issue/AXIMST-719/staticurlerrors-Static-URL-files-cannot-be-opened-because-BASE-URL-is-app-studio-mfe-dev.raccoongang.com)