### PR TITLE
fix: [AXIMST-655] Fixed position of the view-port after loading the unit page

### DIFF
--- a/src/course-unit/CourseUnit.jsx
+++ b/src/course-unit/CourseUnit.jsx
@@ -70,6 +70,10 @@ const CourseUnit = ({ courseId }) => {
     setUnitXBlocks(courseVerticalChildren.children);
   }, [courseVerticalChildren.children]);
 
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, []);
+
   const {
     isShow: isShowProcessingNotification,
     title: processingNotificationTitle,


### PR DESCRIPTION
[YouTrack](https://youtrack.raccoongang.com/issue/AXIMST-655/unitpageposition-When-the-user-opens-the-unit-page-the-buttom-of-the-page-is-displayed)