### PR TITLE
fix: [AXIMST-738] Unit page tagging add margin to the tag button

### DIFF
--- a/src/course-unit/course-xblock/CourseXBlock.jsx
+++ b/src/course-unit/course-xblock/CourseXBlock.jsx
@@ -120,7 +120,7 @@ const CourseXBlock = ({
               {
                 isContentTaxonomyTagsCountLoaded
                 && contentTaxonomyTagsCount > 0
-                && <div className="mr-2"><TagCount count={contentTaxonomyTagsCount} /></div>
+                && <div className="ml-2"><TagCount count={contentTaxonomyTagsCount} /></div>
               }
               <IconButton
                 alt={intl.formatMessage(messages.blockAltButtonEdit)}


### PR DESCRIPTION
[AXIMST-738](https://youtrack.raccoongang.com/issue/AXIMST-738) [tag_icon] The margin-left is missing for tag count