### PR TITLE
fix: [AXIMST-745] added studioBaseUrl for static paths

### DIFF
--- a/src/course-unit/course-xblock/xblock-content/iframe-wrapper/iframe-wrapper.js
+++ b/src/course-unit/course-xblock/xblock-content/iframe-wrapper/iframe-wrapper.js
@@ -273,6 +273,7 @@ export default function wrapBlockHtmlForIFrame(
     'src="/media': `src="${studioBaseUrl}/media`,
     ': "/asset': `: "${studioBaseUrl}/asset`,
     ': "/xblock': `: "${studioBaseUrl}/xblock`,
+    ': "/static': `: "${studioBaseUrl}/static`,
   };
 
   modifiedHtml = modifyVoidHrefToPreventDefault(html);


### PR DESCRIPTION
[YouTrack](https://youtrack.raccoongang.com/issue/AXIMST-745/DragDrop-an-error-appears-while-rendering-the-xblock)