### PR TITLE
feat: [FC-0044] Unit page - manage tags xblocks

### DIFF
--- a/src/course-unit/course-xblock/CourseXBlock.jsx
+++ b/src/course-unit/course-xblock/CourseXBlock.jsx
@@ -165,7 +165,7 @@ const CourseXBlock = memo(({
               {
                 isContentTaxonomyTagsCountLoaded
                 && contentTaxonomyTagsCount > 0
-                && <div className="mr-2"><TagCount count={contentTaxonomyTagsCount} /></div>
+                && <div className="ml-2"><TagCount count={contentTaxonomyTagsCount} /></div>
               }
               <IconButton
                 alt={intl.formatMessage(messages.blockAltButtonEdit)}

--- a/src/course-unit/course-xblock/CourseXBlock.jsx
+++ b/src/course-unit/course-xblock/CourseXBlock.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import {
-  ActionRow, Card, Dropdown, Icon, IconButton, useToggle, OverlayTrigger, Tooltip, Button, Sheet
+  ActionRow, Card, Dropdown, Icon, IconButton, useToggle, OverlayTrigger, Tooltip, Button, Sheet,
 } from '@openedx/paragon';
 import {
   EditOutline as EditIcon,
@@ -16,7 +16,6 @@ import {
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { find } from 'lodash';
 import classNames from 'classnames';
-import { getConfig } from '@edx/frontend-platform';
 
 import ContentTagsDrawer from '../../content-tags-drawer/ContentTagsDrawer';
 import { useContentTagsCount } from '../../generic/data/apiHooks';
@@ -69,7 +68,7 @@ const CourseXBlock = memo(({
   }, [isXBlocksExpanded, isXBlocksRendered]);
 
   const {
-    canCopy, canDelete, canDuplicate, canManageAccess, canMove,
+    canCopy, canDelete, canDuplicate, canManageAccess, canMove, canManageTags,
   } = actions;
 
   const {
@@ -163,7 +162,8 @@ const CourseXBlock = memo(({
           actions={(
             <ActionRow className="mr-2">
               {
-                isContentTaxonomyTagsCountLoaded
+                canManageTags
+                && isContentTaxonomyTagsCountLoaded
                 && contentTaxonomyTagsCount > 0
                 && <div className="ml-2"><TagCount count={contentTaxonomyTagsCount} onClick={openManageTagsModal} /></div>
               }
@@ -181,24 +181,24 @@ const CourseXBlock = memo(({
                   iconAs={Icon}
                 />
                 <Dropdown.Menu>
-                  {canDuplicate && (
-                    <Dropdown.Item onClick={() => unitXBlockActions.handleDuplicate(id)}>
-                      {intl.formatMessage(messages.blockLabelButtonDuplicate)}
-                    </Dropdown.Item>
-                  )}
-                  {getConfig().ENABLE_TAGGING_TAXONOMY_PAGES && (
+                  {canManageTags && (
                     <Dropdown.Item onClick={openManageTagsModal}>
                       {intl.formatMessage(messages.blockLabelButtonManageTags)}
-                    </Dropdown.Item>
-                  )}
-                  {canMove && (
-                    <Dropdown.Item>
-                      {intl.formatMessage(messages.blockLabelButtonMove)}
                     </Dropdown.Item>
                   )}
                   {canCopy && (
                     <Dropdown.Item onClick={() => dispatch(copyToClipboard(id))}>
                       {intl.formatMessage(messages.blockLabelButtonCopyToClipboard)}
+                    </Dropdown.Item>
+                  )}
+                  {canDuplicate && (
+                    <Dropdown.Item onClick={() => unitXBlockActions.handleDuplicate(id)}>
+                      {intl.formatMessage(messages.blockLabelButtonDuplicate)}
+                    </Dropdown.Item>
+                  )}
+                  {canMove && (
+                    <Dropdown.Item>
+                      {intl.formatMessage(messages.blockLabelButtonMove)}
                     </Dropdown.Item>
                   )}
                   {canManageAccess && (
@@ -301,6 +301,7 @@ CourseXBlock.propTypes = {
     canDelete: PropTypes.bool,
     canDuplicate: PropTypes.bool,
     canManageAccess: PropTypes.bool,
+    canManageTags: PropTypes.bool,
     canMove: PropTypes.bool,
   }).isRequired,
   isXBlocksExpanded: PropTypes.bool.isRequired,

--- a/src/course-unit/course-xblock/CourseXBlock.jsx
+++ b/src/course-unit/course-xblock/CourseXBlock.jsx
@@ -165,7 +165,7 @@ const CourseXBlock = memo(({
               {
                 isContentTaxonomyTagsCountLoaded
                 && contentTaxonomyTagsCount > 0
-                && <div className="ml-2"><TagCount count={contentTaxonomyTagsCount} /></div>
+                && <div className="ml-2"><TagCount count={contentTaxonomyTagsCount} onClick={openManageTagsModal} /></div>
               }
               <IconButton
                 alt={intl.formatMessage(messages.blockAltButtonEdit)}

--- a/src/course-unit/course-xblock/CourseXBlock.jsx
+++ b/src/course-unit/course-xblock/CourseXBlock.jsx
@@ -19,7 +19,7 @@ import classNames from 'classnames';
 import { getConfig } from '@edx/frontend-platform';
 
 import ContentTagsDrawer from '../../content-tags-drawer/ContentTagsDrawer';
-import { useContentTaxonomyTagsCount } from '../../content-tags-drawer/data/apiHooks';
+import { useContentTagsCount } from '../../generic/data/apiHooks';
 import TagCount from '../../generic/tag-count';
 import DeleteModal from '../../generic/delete-modal/DeleteModal';
 import ConfigureModal from '../../generic/configure-modal/ConfigureModal';
@@ -75,7 +75,7 @@ const CourseXBlock = memo(({
   const {
     data: contentTaxonomyTagsCount,
     isSuccess: isContentTaxonomyTagsCountLoaded,
-  } = useContentTaxonomyTagsCount(id || '');
+  } = useContentTagsCount(id || '');
 
   const visibilityMessage = userPartitionInfo.selectedGroupsLabel
     ? intl.formatMessage(messages.visibilityMessage, { selectedGroupsLabel: userPartitionInfo.selectedGroupsLabel })

--- a/src/course-unit/course-xblock/CourseXBlock.test.jsx
+++ b/src/course-unit/course-xblock/CourseXBlock.test.jsx
@@ -44,6 +44,13 @@ const unitXBlockActionsMock = {
 };
 const xblockActions = camelCaseObject(actions);
 
+jest.mock('../../content-tags-drawer/data/apiHooks', () => ({
+  useContentTaxonomyTagsCount: jest.fn(() => ({
+    isSuccess: true,
+    data: 17,
+  })),
+}));
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockedUsedNavigate,

--- a/src/course-unit/course-xblock/CourseXBlock.test.jsx
+++ b/src/course-unit/course-xblock/CourseXBlock.test.jsx
@@ -8,6 +8,7 @@ import { camelCaseObject, initializeMockApp } from '@edx/frontend-platform';
 import { AppProvider } from '@edx/frontend-platform/react';
 import MockAdapter from 'axios-mock-adapter';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import configureModalMessages from '../../generic/configure-modal/messages';
 import deleteModalMessages from '../../generic/delete-modal/messages';
@@ -44,13 +45,6 @@ const unitXBlockActionsMock = {
 };
 const xblockActions = camelCaseObject(actions);
 
-jest.mock('../../content-tags-drawer/data/apiHooks', () => ({
-  useContentTaxonomyTagsCount: jest.fn(() => ({
-    isSuccess: true,
-    data: 17,
-  })),
-}));
-
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockedUsedNavigate,
@@ -61,22 +55,33 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
 
+const mockGetTagsCount = jest.fn();
+
+jest.mock('../../generic/data/api', () => ({
+  ...jest.requireActual('../../generic/data/api'),
+  getTagsCount: () => mockGetTagsCount(),
+}));
+
+const queryClient = new QueryClient();
+
 const renderComponent = (props) => render(
   <AppProvider store={store}>
-    <IntlProvider locale="en">
-      <CourseXBlock
-        id={id}
-        title={name}
-        type={type}
-        blockId={blockId}
-        unitXBlockActions={unitXBlockActionsMock}
-        userPartitionInfo={userPartitionInfoFormatted}
-        shouldScroll={false}
-        handleConfigureSubmit={handleConfigureSubmitMock}
-        actions={xblockActions}
-        {...props}
-      />
-    </IntlProvider>
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en">
+        <CourseXBlock
+          id={id}
+          title={name}
+          type={type}
+          blockId={blockId}
+          unitXBlockActions={unitXBlockActionsMock}
+          userPartitionInfo={userPartitionInfoFormatted}
+          shouldScroll={false}
+          handleConfigureSubmit={handleConfigureSubmitMock}
+          actions={xblockActions}
+          {...props}
+        />
+      </IntlProvider>
+    </QueryClientProvider>
   </AppProvider>,
 );
 

--- a/src/course-unit/course-xblock/messages.js
+++ b/src/course-unit/course-xblock/messages.js
@@ -40,6 +40,10 @@ const messages = defineMessages({
     defaultMessage: 'Delete',
     description: 'The xblock delete button text',
   },
+  blockLabelButtonManageTags: {
+    id: 'course-authoring.course-unit.xblock.button.manageTags.label',
+    defaultMessage: 'Manage tags',
+  },
   visibilityMessage: {
     id: 'course-authoring.course-unit.xblock.visibility.message',
     defaultMessage: 'Access restricted to: {selectedGroupsLabel}',

--- a/src/generic/tag-count/TagCount.test.jsx
+++ b/src/generic/tag-count/TagCount.test.jsx
@@ -1,20 +1,28 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+
 import TagCount from '.';
+
+const renderComponent = (props) => render(
+  <IntlProvider locale="en">
+    <TagCount {...props} />,
+  </IntlProvider>,
+);
 
 describe('<TagCount>', () => {
   it('should render the component', () => {
-    render(<TagCount count={17} />);
+    renderComponent({ count: 17 });
     expect(screen.getByText('17')).toBeInTheDocument();
   });
 
   it('should render the component with zero', () => {
-    render(<TagCount count={0} />);
+    renderComponent({ count: 0 });
     expect(screen.getByText('0')).toBeInTheDocument();
   });
 
   it('should render a button with onClick', () => {
-    render(<TagCount count={17} onClick={() => {}} />);
+    renderComponent({ count: 17, onClick: () => {} });
     expect(screen.getByRole('button', {
       name: /17/i,
     }));

--- a/src/generic/tag-count/index.jsx
+++ b/src/generic/tag-count/index.jsx
@@ -1,9 +1,16 @@
 import PropTypes from 'prop-types';
-import { Icon, Button } from '@openedx/paragon';
+import {
+  Icon, Button, OverlayTrigger, Tooltip,
+} from '@openedx/paragon';
 import { Tag } from '@openedx/paragon/icons';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import classNames from 'classnames';
 
+import messages from './messages';
+
 const TagCount = ({ count, onClick }) => {
+  const intl = useIntl();
+
   const renderContent = () => (
     <>
       <Icon className="mr-1 pt-1" src={Tag} />
@@ -17,9 +24,19 @@ const TagCount = ({ count, onClick }) => {
     }
     >
       { onClick ? (
-        <Button variant="tertiary" onClick={onClick}>
-          {renderContent()}
-        </Button>
+        <OverlayTrigger
+          placement="top"
+          overlay={(
+            <Tooltip id={intl.formatMessage(messages.tooltipText)}>
+              {intl.formatMessage(messages.tooltipText)}
+            </Tooltip>
+          )}
+        >
+          <Button variant="tertiary" onClick={onClick}>
+            {renderContent()}
+          </Button>
+        </OverlayTrigger>
+
       )
         : renderContent()}
     </div>

--- a/src/generic/tag-count/messages.js
+++ b/src/generic/tag-count/messages.js
@@ -1,0 +1,10 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  tooltipText: {
+    id: 'course-authoring.generic.tag-count.tooltip.text',
+    defaultMessage: 'Manage tags',
+  },
+});
+
+export default messages;


### PR DESCRIPTION
## In this PR:

    added the tag counter for each component on the Course Unit page;
    added "Manage Tags" menu item with handler to open/close Tags menu;
    reordered menu items due to this https://github.com/openedx/frontend-app-course-authoring/issues/966.

## Developer notes

This PR is temporary built on https://github.com/openedx/frontend-app-course-authoring/pull/964. So only last 5 commits starting from feat: [AXIMST-560] display tags count on each component are relevant to this feature.

## Testing instructions

    Run master devstack.
    Start platform make dev.up.lms+cms+frontend-app-course-authoring and make checkout on this branch.
    Enable the new Unit page by adding a waffle flag contentstore.new_studio_mfe.use_new_unit_page in the CMS admin panel.
    Go to the Course Unit page from the Course Outline page.
    Add a new xblock component.